### PR TITLE
fix: allow objects with EMPTY geom in dc_combine_bbox()

### DIFF
--- a/R/dc_combine_bbox.R
+++ b/R/dc_combine_bbox.R
@@ -24,10 +24,10 @@
 dc_combine_bbox <- function(list_layers) {
   combined_bbox <- Reduce(function(b1, b2) {
     c(
-      xmin = min(b1["xmin"], b2["xmin"]),
-      ymin = min(b1["ymin"], b2["ymin"]),
-      xmax = max(b1["xmax"], b2["xmax"]),
-      ymax = max(b1["ymax"], b2["ymax"])
+      xmin = min(b1["xmin"], b2["xmin"], na.rm = TRUE),
+      ymin = min(b1["ymin"], b2["ymin"], na.rm = TRUE),
+      xmax = max(b1["xmax"], b2["xmax"], na.rm = TRUE),
+      ymax = max(b1["ymax"], b2["ymax"], na.rm = TRUE)
     )
   }, lapply(list_layers, sf::st_bbox))
 


### PR DESCRIPTION
List of sf objects returned by `maposm::om_get()`  may contain EMPTY geom objects (e.g. buldings in large queries). 
The PR allows to ignore sf objetcs with NA values in bbox.

